### PR TITLE
feat: add agentId namespace support for memory isolation

### DIFF
--- a/resources.js
+++ b/resources.js
@@ -231,13 +231,14 @@ export class SlackWebhook extends Resource {
 		return { status: 200, message: 'accepted' };
 	}
 
-	async _processMessage(data) {
+	async _processMessage(data, agentId) {
 		const event = data.event;
 
 		log('info', 'Processing Slack message', {
 			channel: event.channel,
 			user: event.user,
 			eventId: data.event_id,
+			agentId,
 		});
 
 		// Check for duplicate event_id to prevent re-processing
@@ -269,6 +270,7 @@ export class SlackWebhook extends Resource {
 			channelName: event.channel_name || '',
 			authorId: event.user,
 			authorName: '',
+			agentId: agentId || null,
 			classification: classification.category,
 			entities: classification.entities,
 			embedding,
@@ -353,6 +355,9 @@ export class MemorySearch extends Resource {
 			}
 			if (filters.authorId) {
 				conditions.push({ attribute: 'authorId', comparator: 'equals', value: filters.authorId });
+			}
+			if (filters.agentId) {
+				conditions.push({ attribute: 'agentId', comparator: 'equals', value: filters.agentId });
 			}
 
 			if (conditions.length === 1) {

--- a/schema.graphql
+++ b/schema.graphql
@@ -26,6 +26,7 @@ type Memory @table {
 	channelName: String
 	authorId: String @indexed
 	authorName: String
+	agentId: String @indexed
 	classification: String @indexed
 	entities: Any
 	embedding: [Float] @indexed(type: "HNSW", distance: "cosine")

--- a/test/namespace.test.js
+++ b/test/namespace.test.js
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+const mockSearch = mock.fn(function*() {});
+
+class MockMemory {
+	static put = mock.fn();
+	static search = mockSearch;
+	static get = mock.fn();
+}
+
+mock.module('harperdb', {
+	namedExports: {
+		Resource: class Resource {},
+		tables: { Memory: MockMemory, SynapseEntry: class {} },
+	},
+});
+
+mock.module('@anthropic-ai/sdk', {
+	defaultExport: class Anthropic {
+		constructor() {
+			this.messages = { create: mock.fn() };
+		}
+	},
+});
+
+const mockExtractor = mock.fn();
+mock.module('@xenova/transformers', {
+	namedExports: {
+		pipeline: mock.fn(async () => mockExtractor),
+	},
+});
+
+process.env.ANTHROPIC_API_KEY = 'test-key';
+
+const { MemorySearch } = await import('../resources.js');
+
+describe('MemorySearch with agentId', () => {
+	it('accepts agentId in filters', async () => {
+		mockExtractor.mock.mockImplementation(async () => ({
+			data: new Float32Array(384).fill(0.5),
+		}));
+
+		let capturedParams;
+		mockSearch.mock.mockImplementation(function*(params) {
+			capturedParams = params;
+		});
+
+		const search = new MemorySearch();
+		await search.post({
+			query: 'test',
+			filters: { agentId: 'agent-123' },
+		});
+
+		assert.ok(capturedParams.conditions);
+		assert.equal(capturedParams.conditions.attribute, 'agentId');
+		assert.equal(capturedParams.conditions.value, 'agent-123');
+	});
+
+	it('combines agentId with other filters', async () => {
+		mockExtractor.mock.mockImplementation(async () => ({
+			data: new Float32Array(384).fill(0.5),
+		}));
+
+		let capturedParams;
+		mockSearch.mock.mockImplementation(function*(params) {
+			capturedParams = params;
+		});
+
+		const search = new MemorySearch();
+		await search.post({
+			query: 'test',
+			filters: { agentId: 'agent-123', classification: 'decision' },
+		});
+
+		assert.ok(Array.isArray(capturedParams.conditions));
+		assert.equal(capturedParams.conditions.length, 2);
+		const agentIdCondition = capturedParams.conditions.find(c => c.attribute === 'agentId');
+		assert.ok(agentIdCondition);
+		assert.equal(agentIdCondition.value, 'agent-123');
+	});
+
+	it('works without agentId (optional)', async () => {
+		mockExtractor.mock.mockImplementation(async () => ({
+			data: new Float32Array(384).fill(0.5),
+		}));
+
+		let capturedParams;
+		mockSearch.mock.mockImplementation(function*(params) {
+			capturedParams = params;
+		});
+
+		const search = new MemorySearch();
+		await search.post({
+			query: 'test',
+			filters: { classification: 'knowledge' },
+		});
+
+		assert.ok(capturedParams.conditions);
+		assert.equal(capturedParams.conditions.attribute, 'classification');
+		assert.equal(capturedParams.conditions.value, 'knowledge');
+	});
+});


### PR DESCRIPTION
## Summary

Adds `agentId` as an indexed field on the Memory table, enabling multi-agent memory isolation.

- Adds `agentId: String @indexed` to `schema.graphql`
- MemorySearch filters by `agentId` when provided
- Enables multiple agents to share a Cortex instance without cross-contamination

## Test plan
- [ ] Unit tests included (`test/namespace.test.js`)
- [ ] Manual test: store memories with different agentIds, verify search isolation