### PR TITLE
Ship AI skill files for autonomous agent development

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,119 @@
+# Cortex — Cursor Rules
+
+You are working in the Cortex monorepo: the memory layer for AI agents, built on Harper Fabric.
+
+## Project Structure
+
+npm workspaces monorepo with 4 packages:
+- `packages/cortex/` — Harper Fabric app (JavaScript). Memory + Synapse tables, classification, embeddings, REST endpoints.
+- `packages/cortex-client/` — TypeScript HTTP SDK for Cortex.
+- `packages/openclaw-memory/` — TypeScript OpenClaw plugin. Auto-recall/capture lifecycle hooks.
+- `packages/cortex-mcp-server/` — TypeScript MCP server. Bridges AI agents to Cortex with auth, safety, rate limiting.
+
+## Code Style (strictly enforced)
+
+- ES modules only (import/export, never require/module.exports)
+- Tabs for indentation (not spaces)
+- Single quotes (not double)
+- Always use braces for if/else/for/while
+- Formatting enforced by dprint — run `npm run format:fix` after changes
+- Linting enforced by oxlint — run `npm run lint:fix` after changes
+
+## Harper Fabric Patterns
+
+### Schema (packages/cortex/schema.graphql)
+
+Tables use GraphQL directives:
+- `@table` — declares a table
+- `@export` — generates automatic REST/WebSocket APIs. Do NOT use on tables extended in resources.js.
+- `@primaryKey` — primary key
+- `@indexed` — standard index
+- `@indexed(type: "HNSW")` — vector index for similarity search (cosine distance)
+- `@relationship(from:)` / `@relationship(to:)` — table relationships
+
+### Resource Classes (packages/cortex/resources/)
+
+Two patterns:
+
+1. **Table extension** — class extends `tables.TableName`, overrides HTTP methods, calls `super` for defaults:
+```javascript
+import { tables } from 'harperdb';
+class MemoryTable extends tables.Memory {
+  async post(data) { /* custom logic + super.post() */ }
+}
+```
+Tables extended this way must NOT have `@export` in the schema.
+
+2. **Custom resource** — class extends `Resource`, class name = URL path:
+```javascript
+import { Resource } from 'harperdb';
+class MemorySearch extends Resource {
+  async post(data) { return { results }; }
+}
+```
+
+### Vector Search
+
+```javascript
+for await (const result of Table.search({
+  sort: { attribute: 'embedding', value: queryVector, algorithm: 'HNSW' },
+  conditions: [{ attribute: 'embedding', comparator: 'lt', value: threshold }],
+  limit: topK,
+})) { /* ranked by similarity */ }
+```
+
+### Important Constraints
+
+- Harper Resource `post()` receives only parsed JSON body — no HTTP headers are accessible
+- Use body-level tokens for webhook authentication (see slack-webhook.js)
+- Harper Resources always return HTTP 200 — status codes in response body are application-level metadata
+- Embeddings are 384-dimensional (all-MiniLM-L6-v2, ONNX, runs locally)
+- Classification is provider-agnostic (Anthropic, OpenAI, Google, Ollama, or local keyword fallback)
+
+### Config (packages/cortex/config.yaml)
+
+```yaml
+loadEnv:
+  files: '.env'
+rest: true
+graphqlSchema:
+  files: 'schema.graphql'
+jsResource:
+  files: 'resources.js'
+  resources: '*'
+```
+
+## Memory Write Pipeline
+
+All ingestion follows: receive -> classify -> embed -> store
+1. Validate/authenticate the incoming payload
+2. `classifyMessage(text)` -> `{ category, entities, summary }`
+3. `generateEmbedding(text)` -> 384-dim Float32Array
+4. `Memory.put(record)` -> stored with HNSW vector index
+
+## Key Commands
+
+```bash
+npm test                  # All tests (vitest)
+npm run build             # Build TypeScript packages
+npm run format:check      # Check formatting (dprint)
+npm run format:fix        # Fix formatting
+npm run lint:check        # Lint (oxlint)
+npm run dev -w packages/cortex              # Dev server on :9926
+npm run deploy -w packages/cortex           # Deploy to Fabric
+```
+
+## Extension Points
+
+- New ingestion source: add Resource class in `packages/cortex/resources/`, export from `resources.js`
+- New classification provider: add in `resources/classification-provider.js`
+- New embedding model: swap in `resources/shared.js` (update schema dimensions)
+- New MCP tools: add in `packages/cortex-mcp-server/src/tools/`
+- New client API methods: extend `packages/cortex-client/src/`
+- Schema changes: edit `schema.graphql`, no `@export` on extended tables
+
+## Testing
+
+Vitest in workspace mode. Tests live alongside source in each package's `test/` directory.
+Mock `harperdb` module in tests (Resource base class, tables object).
+Run `npm test` from root to execute all packages.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,92 @@
+# Cortex — GitHub Copilot Instructions
+
+You are working in the Cortex monorepo: the memory layer for AI agents, built on Harper Fabric.
+
+## Project Structure
+
+npm workspaces monorepo with 4 packages:
+
+- `packages/cortex/` — Harper Fabric app (JavaScript). Memory + Synapse tables, classification, embeddings, REST endpoints.
+- `packages/cortex-client/` — TypeScript HTTP SDK for Cortex.
+- `packages/openclaw-memory/` — TypeScript OpenClaw plugin. Auto-recall/capture lifecycle hooks.
+- `packages/cortex-mcp-server/` — TypeScript MCP server. Bridges AI agents to Cortex with auth, safety, rate limiting.
+
+## Code Style (strictly enforced)
+
+- ES modules only (import/export, never require/module.exports)
+- Tabs for indentation (not spaces)
+- Single quotes (not double)
+- Always use braces for if/else/for/while
+- Formatting: dprint (not Prettier)
+- Linting: oxlint
+
+## Harper Fabric Patterns
+
+### Schema (packages/cortex/schema.graphql)
+
+Tables use GraphQL directives:
+
+- `@table` — declares a table
+- `@export` — generates automatic REST/WebSocket APIs. Do NOT use on tables extended in resources.js.
+- `@primaryKey` — primary key
+- `@indexed` — standard index
+- `@indexed(type: "HNSW")` — vector index for similarity search (cosine distance)
+- `@relationship(from:)` / `@relationship(to:)` — table relationships
+
+### Resource Classes (packages/cortex/resources/)
+
+Two patterns:
+
+1. **Table extension** — class extends `tables.TableName`, overrides HTTP methods, calls `super` for defaults. Tables extended this way must NOT have `@export` in the schema.
+
+2. **Custom resource** — class extends `Resource` from harperdb. Class name = URL path (e.g., `MemorySearch` -> `/MemorySearch/`).
+
+### Vector Search
+
+```javascript
+for await (
+	const result of Table.search({
+		sort: { attribute: 'embedding', value: queryVector, algorithm: 'HNSW' },
+		conditions: [{
+			attribute: 'embedding',
+			comparator: 'lt',
+			value: threshold,
+		}],
+		limit: topK,
+	})
+) { /* ranked by similarity */ }
+```
+
+### Important Constraints
+
+- Harper Resource `post()` receives only parsed JSON body — no HTTP headers
+- Use body-level tokens for webhook authentication
+- Harper Resources always return HTTP 200 — status in response body is application-level
+- Embeddings: 384-dim, all-MiniLM-L6-v2, local ONNX
+- Classification: provider-agnostic (Anthropic/OpenAI/Google/Ollama/keyword fallback)
+
+## Memory Write Pipeline
+
+receive -> classify -> embed -> store
+
+1. `classifyMessage(text)` -> `{ category, entities, summary }`
+2. `generateEmbedding(text)` -> 384-dim Float32Array
+3. `Memory.put(record)` -> stored with HNSW index
+
+## Extension Points
+
+- New ingestion source: add Resource class in `packages/cortex/resources/`, export from `resources.js`
+- New classification provider: add in `resources/classification-provider.js`
+- New embedding model: swap in `resources/shared.js` (update schema dimensions)
+- New MCP tools: add in `packages/cortex-mcp-server/src/tools/`
+- Schema changes: edit `schema.graphql`, no `@export` on extended tables
+
+## Commands
+
+```bash
+npm test                  # All tests (vitest)
+npm run build             # Build TypeScript packages
+npm run format:fix        # Fix formatting (dprint)
+npm run lint:fix          # Fix linting (oxlint)
+npm run dev -w packages/cortex   # Dev server on :9926
+```

--- a/.windsurf/rules/cortex.md
+++ b/.windsurf/rules/cortex.md
@@ -1,0 +1,133 @@
+# Cortex — Windsurf Rules
+
+You are working in the Cortex monorepo: the memory layer for AI agents, built on Harper Fabric.
+
+## Project Structure
+
+npm workspaces monorepo with 4 packages:
+
+- `packages/cortex/` — Harper Fabric app (JavaScript). Memory + Synapse tables, classification, embeddings, REST endpoints.
+- `packages/cortex-client/` — TypeScript HTTP SDK for Cortex.
+- `packages/openclaw-memory/` — TypeScript OpenClaw plugin. Auto-recall/capture lifecycle hooks.
+- `packages/cortex-mcp-server/` — TypeScript MCP server. Bridges AI agents to Cortex with auth, safety, rate limiting.
+
+## Code Style (strictly enforced)
+
+- ES modules only (import/export, never require/module.exports)
+- Tabs for indentation (not spaces)
+- Single quotes (not double)
+- Always use braces for if/else/for/while
+- Formatting enforced by dprint — run `npm run format:fix` after changes
+- Linting enforced by oxlint — run `npm run lint:fix` after changes
+
+## Harper Fabric Patterns
+
+### Schema (packages/cortex/schema.graphql)
+
+Tables use GraphQL directives:
+
+- `@table` — declares a table
+- `@export` — generates automatic REST/WebSocket APIs. Do NOT use on tables extended in resources.js.
+- `@primaryKey` — primary key
+- `@indexed` — standard index
+- `@indexed(type: "HNSW")` — vector index for similarity search (cosine distance)
+- `@relationship(from:)` / `@relationship(to:)` — table relationships
+
+### Resource Classes (packages/cortex/resources/)
+
+Two patterns:
+
+1. **Table extension** — class extends `tables.TableName`, overrides HTTP methods, calls `super` for defaults:
+
+```javascript
+import { tables } from 'harperdb';
+class MemoryTable extends tables.Memory {
+	async post(data) {/* custom logic + super.post() */}
+}
+```
+
+Tables extended this way must NOT have `@export` in the schema.
+
+2. **Custom resource** — class extends `Resource`, class name = URL path:
+
+```javascript
+import { Resource } from 'harperdb';
+class MemorySearch extends Resource {
+	async post(data) {
+		return { results };
+	}
+}
+```
+
+### Vector Search
+
+```javascript
+for await (
+	const result of Table.search({
+		sort: { attribute: 'embedding', value: queryVector, algorithm: 'HNSW' },
+		conditions: [{
+			attribute: 'embedding',
+			comparator: 'lt',
+			value: threshold,
+		}],
+		limit: topK,
+	})
+) { /* ranked by similarity */ }
+```
+
+### Important Constraints
+
+- Harper Resource `post()` receives only parsed JSON body — no HTTP headers are accessible
+- Use body-level tokens for webhook authentication (see slack-webhook.js)
+- Harper Resources always return HTTP 200 — status codes in response body are application-level metadata
+- Embeddings are 384-dimensional (all-MiniLM-L6-v2, ONNX, runs locally)
+- Classification is provider-agnostic (Anthropic, OpenAI, Google, Ollama, or local keyword fallback)
+
+### Config (packages/cortex/config.yaml)
+
+```yaml
+loadEnv:
+  files: '.env'
+rest: true
+graphqlSchema:
+  files: 'schema.graphql'
+jsResource:
+  files: 'resources.js'
+  resources: '*'
+```
+
+## Memory Write Pipeline
+
+All ingestion follows: receive -> classify -> embed -> store
+
+1. Validate/authenticate the incoming payload
+2. `classifyMessage(text)` -> `{ category, entities, summary }`
+3. `generateEmbedding(text)` -> 384-dim Float32Array
+4. `Memory.put(record)` -> stored with HNSW vector index
+
+## Key Commands
+
+```bash
+npm test                  # All tests (vitest)
+npm run build             # Build TypeScript packages
+npm run format:check      # Check formatting (dprint)
+npm run format:fix        # Fix formatting
+npm run lint:check        # Lint (oxlint)
+npm run dev -w packages/cortex              # Dev server on :9926
+npm run deploy -w packages/cortex           # Deploy to Fabric
+```
+
+## Extension Points
+
+- New ingestion source: add Resource class in `packages/cortex/resources/`, export from `resources.js`
+- New classification provider: add in `resources/classification-provider.js`
+- New embedding model: swap in `resources/shared.js` (update schema dimensions)
+- New MCP tools: add in `packages/cortex-mcp-server/src/tools/`
+- New client API methods: extend `packages/cortex-client/src/`
+- Schema changes: edit `schema.graphql`, no `@export` on extended tables
+
+## Testing
+
+Vitest in workspace mode. Tests live alongside source in each package's `test/` directory.
+Mock `harperdb` module in tests (Resource base class, tables object).
+Run `npm test` from root to execute all packages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,147 @@
+# Cortex — Agent Guide
+
+This file provides AI coding agents with the knowledge needed to understand, modify, and extend Cortex autonomously. Cortex is the memory layer for AI agents — persistent, distributed, open source, built on Harper Fabric.
+
+## Architecture
+
+```
+AI Agents (Claude, Cursor, Windsurf, OpenClaw, LangChain)
+    |
+    +-- MCP protocol --> cortex-mcp-server (auth, safety, rate limiting)
+    +-- HTTP / SDK ----> cortex-client
+    +-- Plugin hooks --> openclaw-memory (auto-recall / auto-capture)
+          |
+    [Cortex Core on Harper Fabric]
+    Memory table (HNSW) + SynapseEntry table (HNSW)
+    classify -> embed (ONNX, local) -> store
+    MemorySearch | REST | MQTT real-time
+```
+
+## Monorepo Layout
+
+```
+packages/
+  cortex/                  # Harper Fabric app (JavaScript)
+    schema.graphql         #   Table definitions with HNSW vector indexes
+    config.yaml            #   Harper app config
+    resources.js           #   Barrel re-export (all resource classes)
+    resources/             #   Modular resource implementations
+      memory.js            #     MemoryTable, MemorySearch, MemoryStore, etc.
+      synapse.js           #     SynapseEntry, SynapseSearch, SynapseIngest, etc.
+      slack-webhook.js     #     SlackWebhook (Slack Events API ingestion)
+      shared.js            #     generateEmbedding, log, constants
+      classification-provider.js  # Provider-agnostic LLM classification
+    bin/synapse.js         #   Synapse CLI
+  cortex-client/           # TypeScript HTTP SDK
+    src/client.ts          #   Client core
+    src/memory.ts          #   Memory API methods
+    src/synapse.ts         #   Synapse API methods
+  openclaw-memory/         # TypeScript OpenClaw plugin
+    src/lifecycle.ts       #   auto-recall + auto-capture hooks
+    src/safety.ts          #   Content safety filtering
+  cortex-mcp-server/       # TypeScript MCP server
+    src/index.ts           #   Server entry (stdio + HTTP transport)
+    src/tools/             #   MCP tool implementations
+    src/auth.ts            #   JWT/JWKS auth
+    harper/                #   Self-contained Harper deployment
+```
+
+## Code Conventions
+
+- **ES modules** exclusively (import/export, no CommonJS)
+- **Tabs** for indentation, **single quotes**, **always braces** (enforced by dprint)
+- **No `@export`** on tables extended in resources.js — the resource class IS the API
+- **Vitest** for all tests (workspace mode, run with `npm test`)
+- **oxlint** for linting, **dprint** for formatting
+- Shared devDependencies at root, package-specific deps in each package
+- Conventional commits for automated semantic versioning
+
+## Harper Fabric Patterns
+
+### Schema (schema.graphql)
+
+Tables use GraphQL directives:
+
+- `@table` — declares a Harper table
+- `@export` — auto-generates REST/WebSocket APIs (omit for tables extended in resources.js)
+- `@primaryKey` — primary key field
+- `@indexed` — standard query index
+- `@indexed(type: "HNSW")` — HNSW vector index for similarity search (cosine distance)
+- `@relationship(from: "field")` / `@relationship(to: "field")` — table relationships
+
+### Resource Classes
+
+**Table extension** — extends auto-generated table, overrides HTTP methods:
+
+```javascript
+import { tables } from 'harperdb';
+class MemoryTable extends tables.Memory {
+	async post(data) {/* validate, transform, then super.post() */}
+}
+```
+
+**Custom resource** — standalone endpoint, class name = URL path:
+
+```javascript
+import { Resource } from 'harperdb';
+class MemorySearch extends Resource {
+	async post(data) {/* custom logic, return JSON */}
+}
+```
+
+### Vector Search
+
+```javascript
+for await (
+	const result of Table.search({
+		sort: { attribute: 'embedding', value: vector, algorithm: 'HNSW' },
+		conditions: [{
+			attribute: 'embedding',
+			comparator: 'lt',
+			value: threshold,
+		}],
+		limit: topK,
+	})
+) { /* ranked results */ }
+```
+
+### Memory Write Pipeline
+
+All ingestion follows: **receive -> classify -> embed -> store**
+
+1. Validate and authenticate
+2. `classifyMessage(text)` — LLM or keyword fallback -> `{ category, entities, summary }`
+3. `generateEmbedding(text)` — local ONNX, 384-dim vector
+4. `Memory.put(record)` — stored with HNSW index
+
+### Adding New Webhook Sources
+
+Create a Resource class in `resources/`, verify body-level tokens (no HTTP headers available in Harper Resources), classify + embed + store, export from `resources.js`. See `slack-webhook.js` for reference.
+
+### Config (config.yaml)
+
+Points Harper to `.env`, enables REST, loads `schema.graphql`, and mounts `resources.js` as the resource entry point.
+
+## Development Commands
+
+```bash
+npm ci                    # Install dependencies
+npm test                  # Run all tests
+npm run build             # Build TypeScript packages
+npm run format:check      # Check formatting (dprint)
+npm run format:fix        # Fix formatting
+npm run lint:check        # Lint (oxlint)
+npm run dev -w packages/cortex              # Dev server on :9926
+npm run deploy -w packages/cortex           # Deploy to Fabric
+```
+
+## Extending Cortex
+
+This repo is designed to be cloned and customized. Common extension points:
+
+1. **New ingestion source** — add a Resource class in `packages/cortex/resources/` (GitHub, Discord, Linear, etc.)
+2. **New classification provider** — add a provider in `classification-provider.js`
+3. **New embedding model** — swap the model in `shared.js` (update dimensions in schema)
+4. **New MCP tools** — add tool files in `packages/cortex-mcp-server/src/tools/`
+5. **New client methods** — extend `packages/cortex-client/src/`
+6. **Schema changes** — modify `schema.graphql`, ensure no `@export` on extended tables

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Cortex Monorepo
 
-An agent-agnostic AI memory system using Harper Fabric as the vector database and MCP for AI agent connectivity.
+The memory layer for AI agents. Persistent, distributed, open source. Built on Harper Fabric.
 
 ## Monorepo Structure
 
@@ -16,30 +16,31 @@ This is an npm workspaces monorepo with 4 packages:
 ## Tech Stack
 
 - **Runtime**: Harper Fabric (Node.js-based, ES modules)
-- **Database**: Harper Fabric with HNSW vector indexing
-- **Classification**: Provider-agnostic (Anthropic, OpenAI, Google, Ollama, local fallback)
-- **Embeddings**: `@huggingface/transformers` with `all-MiniLM-L6-v2` (384-dim, ONNX)
-- **Tests**: Vitest (workspace mode, ~150 tests across all packages)
-- **Formatting**: dprint (tabs, preferSingle)
+- **Node**: v22+ (see `.nvmrc`)
+- **Database**: Harper Fabric with HNSW vector indexing (cosine distance)
+- **Classification**: Provider-agnostic (Anthropic, OpenAI, Google, Ollama, local keyword fallback)
+- **Embeddings**: `@huggingface/transformers` with `all-MiniLM-L6-v2` (384-dim, ONNX, runs locally)
+- **Tests**: Vitest (workspace mode)
+- **Formatting**: dprint (tabs, single quotes, always braces)
 - **Linting**: oxlint
 
 ## Development
 
 ```bash
-npm ci                # Install all workspace dependencies
-npm test              # Run all tests across all packages
-npm run build         # Build all TypeScript packages
-npm run format:check  # Check formatting (dprint)
-npm run lint:check    # Lint all packages (oxlint)
+npm ci                    # Install all workspace dependencies
+npm test                  # Run all tests across all packages
+npm run build             # Build all TypeScript packages
+npm run format:check      # Check formatting (dprint)
+npm run format:fix        # Auto-fix formatting
+npm run lint:check        # Lint all packages (oxlint)
 ```
 
 ### Package-specific commands
 
 ```bash
 # Cortex Core (Harper Fabric app)
-cd packages/cortex
-npm run dev           # Start Harper dev server on port 9926
-npm run deploy        # Deploy to Harper Fabric
+npm run dev -w packages/cortex          # Start Harper dev server on port 9926
+npm run deploy -w packages/cortex       # Deploy to Harper Fabric
 
 # cortex-mcp-server
 npm run dev -w packages/cortex-mcp-server   # Start MCP server with HTTP transport
@@ -50,9 +51,14 @@ npm run dev -w packages/cortex-mcp-server   # Start MCP server with HTTP transpo
 ### packages/cortex/ (Harper Fabric app)
 
 - `schema.graphql` — Memory + SynapseEntry tables with HNSW vector indexes
-- `config.yaml` — Harper app config
-- `resources/` — Modular resource classes (memory.js, synapse.js, slack-webhook.js, shared.js, classification-provider.js)
-- `resources.js` — Barrel re-export for backward compatibility
+- `config.yaml` — Harper app config (loadEnv, REST, schema, resources)
+- `resources/` — Modular resource classes:
+  - `memory.js` — MemoryTable, MemorySearch, MemoryStore, MemoryCount, VectorSearch, BatchUpsert
+  - `synapse.js` — SynapseEntry, SynapseSearch, SynapseIngest, SynapseEmit
+  - `slack-webhook.js` — SlackWebhook (Slack Events API ingestion)
+  - `shared.js` — generateEmbedding, EMBEDDING_MODEL, log
+  - `classification-provider.js` — Provider-agnostic LLM classification
+- `resources.js` — Barrel re-export for all resource classes
 - `bin/synapse.js` — Synapse CLI
 - `.env.example` — All environment variables documented
 
@@ -76,16 +82,151 @@ npm run dev -w packages/cortex-mcp-server   # Start MCP server with HTTP transpo
 - `src/quota.ts` — Per-agent storage quota enforcement
 - `harper/` — Harper Custom Resource deployment (self-contained)
 
-## Agent Skills
+## Harper Fabric Patterns
 
-Skills from `harperfast/skills` are tracked in `packages/cortex/skills-lock.json`. Refer to the relevant skill rules when modifying Harper-specific files:
+These patterns apply when modifying `packages/cortex/` (the Harper Fabric app).
 
-- **`harper-best-practices`** — Apply when modifying `schema.graphql`, `resources.js`, or `config.yaml`
+### Schema Design (schema.graphql)
+
+Tables are defined with GraphQL directives:
+
+- `@table` — declares a Harper table
+- `@export` — auto-generates REST + WebSocket APIs (do NOT use on tables extended in resources.js)
+- `@primaryKey` — designates the primary key field
+- `@indexed` — adds a standard index for query performance
+- `@indexed(type: "HNSW")` — adds HNSW vector index for similarity search
+- `@relationship(from: "field")` / `@relationship(to: "field")` — defines relationships
+
+Both Memory and SynapseEntry use `embedding: [Float] @indexed(type: "HNSW")` for cosine-distance vector search.
+
+### Resource Classes
+
+Two patterns for extending Harper:
+
+**1. Table extension** (used by Memory, SynapseEntry):
+
+```javascript
+import { tables } from 'harperdb';
+class MemoryTable extends tables.Memory {
+	// Override get/post/put/patch/delete
+	// Call super methods to preserve default behavior
+}
+```
+
+Tables extended this way must NOT have `@export` in the schema — the resource class IS the API.
+
+**2. Custom resource** (used by MemorySearch, SlackWebhook, etc.):
+
+```javascript
+import { Resource } from 'harperdb';
+class MemorySearch extends Resource {
+	async post(data) {/* custom logic */}
+}
+```
+
+Class name = URL path. `MemorySearch` serves at `/MemorySearch/`.
+
+### Vector Search Pattern
+
+```javascript
+for await (
+	const result of Memory.search({
+		sort: { attribute: 'embedding', value: queryEmbedding, algorithm: 'HNSW' },
+		conditions: [{
+			attribute: 'embedding',
+			comparator: 'lt',
+			value: distanceThreshold,
+		}],
+		limit: topK,
+	})
+) {
+	// result has similarity distance in sort metadata
+}
+```
+
+### Config (config.yaml)
+
+```yaml
+loadEnv:
+  files: '.env'
+rest: true
+graphqlSchema:
+  files: 'schema.graphql'
+jsResource:
+  files: 'resources.js'
+  resources: '*'
+```
+
+### Write Path (Memory Pipeline)
+
+All ingestion (Slack, API, MCP) follows: **receive -> classify -> embed -> store**
+
+1. Validate/authenticate the request
+2. `classifyMessage(text)` — returns `{ category, entities, summary }` via LLM or keyword fallback
+3. `generateEmbedding(text)` — returns 384-dim Float32Array via local ONNX
+4. `Memory.put(record)` — stores with vector index for later similarity search
+
+### Adding a New Webhook Source
+
+Create a new Resource class in `resources/`:
+
+```javascript
+import { Resource, tables } from 'harperdb';
+import { classifyMessage } from './memory.js';
+import { generateEmbedding, log } from './shared.js';
+const { Memory } = tables;
+
+export class MyWebhook extends Resource {
+	async post(data) {
+		// 1. Verify authenticity (body-level token — no HTTP headers in Resources)
+		// 2. Extract text + metadata from payload
+		// 3. Classify and embed in parallel:
+		const [classification, embedding] = await Promise.all([
+			classifyMessage(text),
+			generateEmbedding(text),
+		]);
+		// 4. Store:
+		await Memory.put({
+			rawText: text,
+			source: 'my-platform',
+			embedding,
+			...classification,
+		});
+	}
+}
+```
+
+Export from `resources.js` and it's live at `/MyWebhook/`.
+
+**Important**: Harper Resource `post()` only receives parsed JSON body — no HTTP headers. Use body-level tokens for webhook verification.
 
 ## Conventions
 
-- ES module syntax (import/export)
-- No @export on tables that are extended in resources.js
+- ES module syntax everywhere (import/export)
+- No `@export` on tables that are extended in resources.js
+- Tabs for indentation (enforced by dprint)
+- Single quotes (enforced by dprint)
+- Always use braces for control flow (enforced by dprint)
 - Shared TypeScript config: `tsconfig.base.json` at root, extended by each TS package
 - Shared devDependencies (vitest, typescript, dprint, oxlint) at root
 - Package-specific dependencies stay in each package
+- Conventional commits for release automation
+
+## Agent Skills
+
+Skills from `harperfast/skills` are tracked in `packages/cortex/skills-lock.json`. Apply `harper-best-practices` when modifying:
+
+- `schema.graphql` — table definitions, indexes, relationships
+- `resources.js` or `resources/*.js` — resource classes, table extensions
+- `config.yaml` — Harper app configuration
+
+The full skill rules cover: schema design, automatic APIs, vector indexing, custom resources, table extensions, caching, real-time apps, authentication, blob handling, TypeScript type stripping, and Fabric deployment.
+
+## Deployment
+
+```bash
+# Set in .env: CLI_TARGET, CLI_TARGET_USERNAME, CLI_TARGET_PASSWORD
+npm run deploy -w packages/cortex    # Deploy to Harper Fabric
+```
+
+CI/CD runs on push: format check -> lint -> build -> test. Releases via multi-semantic-release on merge to main.


### PR DESCRIPTION
## Summary

Cortex now ships with full AI tool knowledge so that any coding agent — Claude Code, Cursor, Windsurf, or GitHub Copilot — can understand the codebase and modify it autonomously out of the box.

Clone the repo, open it in your editor, and your AI already knows:
- The monorepo structure (4 packages, what each does)
- Harper Fabric patterns (schema directives, resource classes, table extensions, vector search, config)
- The memory write pipeline (receive → classify → embed → store)
- Key constraints (no HTTP headers in Resources, no `@export` on extended tables, 384-dim embeddings)
- How to extend Cortex (new ingestion sources, classification providers, MCP tools, client methods)
- Code conventions (tabs, single quotes, dprint, oxlint, vitest)

### Files added/updated

| File | Tool | Purpose |
|------|------|---------|
| `CLAUDE.md` | Claude Code | Enhanced with Harper patterns, vector search, webhook template, deployment |
| `AGENTS.md` | Copilot, Junie, generic agents | Full architecture, layout, patterns, extension points |
| `.cursorrules` | Cursor | Complete rules file |
| `.windsurf/rules/cortex.md` | Windsurf Cascade | Complete rules file |
| `.github/copilot-instructions.md` | GitHub Copilot | Concise instructions for Copilot's context window |

All content is derived from the [harperfast/skills](https://github.com/HarperFast/skills) `harper-best-practices` skill and the actual Cortex codebase patterns.

## Test plan

- [x] All 331 tests pass
- [x] `dprint check` clean
- [x] No functional code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)